### PR TITLE
Add simple copyright info web app

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Paulo Vitor Nascimento
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Sistema de Direitos Autorais
+
+Este é um exemplo simples de aplicação web para cadastrar e consultar informações de direitos autorais de artistas. Não requer autenticação e funciona como uma pequena wiki aberta.
+
+## Como executar
+
+1. Instale as dependências (Flask e requests).
+   ```bash
+   pip install flask requests
+   ```
+2. Inicie a aplicação:
+   ```bash
+   python app/app.py
+   ```
+3. Acesse `http://localhost:5000` no navegador.
+
+Os dados são armazenados em um banco SQLite em `app/data.db`.
+
+## Integração com Shoutcast
+
+Envie dados de reprodução via POST para `/api/shoutcast/plays` no formato JSON:
+
+```json
+{
+  "artist": "Nome do artista",
+  "title": "Título da música",
+  "played_at": "2024-01-01T12:00:00Z"
+}
+```
+
+Essas informações serão gravadas na tabela `plays`.
+
+## Licença
+
+Este projeto está licenciado sob os termos da [MIT License](LICENSE).

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+from .app import app, init_db, fetch_shoutcast

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,112 @@
+from flask import Flask, render_template, request, redirect, url_for
+import sqlite3
+from pathlib import Path
+import requests
+from datetime import datetime
+
+DB_PATH = Path('app/data.db')
+
+app = Flask(__name__)
+
+# Initialize database
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS artists (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE,
+            copyright_info TEXT NOT NULL
+        )
+        '''
+    )
+    cur.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS plays (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            artist_name TEXT NOT NULL,
+            title TEXT NOT NULL,
+            played_at TEXT NOT NULL
+        )
+        '''
+    )
+    conn.commit()
+    conn.close()
+
+def store_play(artist_name: str, title: str, played_at: str):
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        'INSERT INTO plays (artist_name, title, played_at) VALUES (?, ?, ?)',
+        (artist_name, title, played_at),
+    )
+    conn.commit()
+    conn.close()
+
+def fetch_shoutcast(url: str):
+    """Fetch current song info from a Shoutcast server."""
+    try:
+        r = requests.get(url, timeout=10)
+        data = r.json()
+        song = data.get('songtitle') or data.get('song')
+        if song:
+            if ' - ' in song:
+                artist, title = song.split(' - ', 1)
+            else:
+                artist, title = '', song
+            store_play(artist.strip(), title.strip(), datetime.utcnow().isoformat())
+            return True
+    except Exception:
+        pass
+    return False
+
+@app.route('/')
+def index():
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute('SELECT id, name FROM artists')
+    artists = cur.fetchall()
+    conn.close()
+    return render_template('index.html', artists=artists)
+
+@app.route('/artist/<int:artist_id>')
+def artist_detail(artist_id):
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute('SELECT id, name, copyright_info FROM artists WHERE id = ?', (artist_id,))
+    artist = cur.fetchone()
+    conn.close()
+    if artist:
+        return render_template('artist.html', artist=artist)
+    return 'Artist not found', 404
+
+@app.route('/new', methods=['GET', 'POST'])
+def new_artist():
+    if request.method == 'POST':
+        name = request.form['name']
+        info = request.form['info']
+        conn = sqlite3.connect(DB_PATH)
+        cur = conn.cursor()
+        cur.execute('SELECT id FROM artists WHERE lower(name) = lower(?)', (name,))
+        if cur.fetchone():
+            conn.close()
+            return 'Artista duplicado', 400
+        cur.execute('INSERT INTO artists (name, copyright_info) VALUES (?, ?)', (name, info))
+        conn.commit()
+        conn.close()
+        return redirect(url_for('index'))
+    return render_template('new_artist.html')
+
+@app.route('/api/shoutcast/plays', methods=['POST'])
+def shoutcast_play():
+    data = request.get_json(force=True)
+    artist = data.get('artist') or ''
+    title = data.get('title') or ''
+    played_at = data.get('played_at') or datetime.utcnow().isoformat()
+    store_play(artist, title, played_at)
+    return {'status': 'ok'}
+
+if __name__ == '__main__':
+    init_db()
+    app.run(debug=True)

--- a/app/shoutcast.py
+++ b/app/shoutcast.py
@@ -1,0 +1,12 @@
+import sys
+from app import fetch_shoutcast, init_db
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print('Usage: python -m app.shoutcast <url>')
+        sys.exit(1)
+    init_db()
+    if fetch_shoutcast(sys.argv[1]):
+        print('Play stored')
+    else:
+        print('Failed to fetch')

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,5 @@
+body { font-family: Arial, sans-serif; margin: 1em; }
+label { display: block; margin-top: 1em; }
+textarea { width: 100%; height: 10em; }
+ul { list-style-type: none; padding: 0; }
+li { margin: 0.5em 0; }

--- a/app/templates/artist.html
+++ b/app/templates/artist.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="pt">
+<head>
+    <meta charset="utf-8">
+    <title>{{ artist[1] }}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>{{ artist[1] }}</h1>
+    <p>{{ artist[2] }}</p>
+    <a href="{{ url_for('index') }}">Voltar</a>
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="pt">
+<head>
+    <meta charset="utf-8">
+    <title>Artistas</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Artistas</h1>
+    <a href="{{ url_for('new_artist') }}">Adicionar novo artista</a>
+    <ul>
+        {% for artist in artists %}
+        <li><a href="{{ url_for('artist_detail', artist_id=artist[0]) }}">{{ artist[1] }}</a></li>
+        {% else %}
+        <li>Nenhum artista cadastrado.</li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/app/templates/new_artist.html
+++ b/app/templates/new_artist.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="pt">
+<head>
+    <meta charset="utf-8">
+    <title>Novo Artista</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Adicionar Artista</h1>
+    <form method="post">
+        <label for="name">Nome:</label>
+        <input type="text" name="name" id="name" required>
+        <label for="info">Informações de direitos autorais:</label>
+        <textarea name="info" id="info" required></textarea>
+        <button type="submit">Salvar</button>
+    </form>
+    <a href="{{ url_for('index') }}">Voltar</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a minimal Flask app to manage artist info
- log Shoutcast track plays via REST
- include CLI helper for fetching Shoutcast metadata
- document how to run the app
- add MIT license

## Testing
- `python -m py_compile app/app.py app/shoutcast.py`
- `python -m app.shoutcast http://example.com` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_68407e8703c08332aaf5593b60f00bce